### PR TITLE
Use tox to run tests on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 build
 dist
 README.rst
+/.eggs/
+/.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,8 @@
+sudo: false
 language: python
 python:
  - "2.7"
+ - "3.3"
  - "3.4"
-env:
- - DJANGO="django==1.6.11" DJANGO_SETTINGS_MODULE="tests.settings"
- - DJANGO="django==1.6.11" DJANGO_SETTINGS_MODULE="tests.swap_settings"
- - DJANGO="django==1.7.7"  DJANGO_SETTINGS_MODULE="tests.settings"
- - DJANGO="django==1.7.7"  DJANGO_SETTINGS_MODULE="tests.swap_settings"
- - DJANGO="django==1.8"    DJANGO_SETTINGS_MODULE="tests.settings"
- - DJANGO="django==1.8"    DJANGO_SETTINGS_MODULE="tests.swap_settings"
-install:
- - pip install $DJANGO
-script:
- - python setup.py test
+install: pip install tox-travis
+script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist =
+    py{27,33}-django16-{noswap,swap},
+    py{27,33,34}-django{17,18}-{noswap,swap}
+
+[tox:travis]
+2.7 = py27-django{16,17,18}-{noswap,swap}
+3.3 = py33-django{17,18}-{noswap,swap}
+3.4 = py34-django{17,18}-{noswap,swap}
+
+[testenv]
+commands = python setup.py test
+deps =
+    django16: django>=1.6
+    django17: django>=1.7
+    django18: django>=1.8
+setenv =
+    noswap: DJANGO_SETTINGS_MODULE=tests.settings
+    swap: DJANGO_SETTINGS_MODULE=tests.swap_settings


### PR DESCRIPTION
tox-travis helps make the configuration simple, running all of the tests for a particular python version on the Travis matrix version of Python.

Add tests of Python 3.3, and drop Python 3.4 from testing with Django 1.6, since it does not support that version of Python.