### PR TITLE
Python 2.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 python:
+ - "2.6"
  - "2.7"
  - "3.3"
  - "3.4"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ arbitrary swappable models in your own reusable apps.
 [![Build Status](https://travis-ci.org/wq/django-swappable-models.svg?branch=master)](https://travis-ci.org/wq/django-swappable-models)
 [![PyPI Package](https://pypip.in/version/swapper/badge.svg?style=flat)](https://pypi.python.org/pypi/swapper)
 
-Tested on Python 2.7 and 3.4, with Django 1.6, 1.7, and 1.8.
+Tested on Python 2.6, 2.7, and 3.4, with Django 1.6, 1.7, and 1.8.
 
 ## Motivation
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/swapper/__init__.py
+++ b/swapper/__init__.py
@@ -57,10 +57,10 @@ def get_model_names(app_label, models):
     """
     Map model names to their swapped equivalents for the given app
     """
-    return {
-        model: get_model_name(app_label, model)
+    return dict(
+        (model, get_model_name(app_label, model))
         for model in models
-    }
+    )
 
 
 def load_model(app_label, model, orm=None, required=True):

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -1,5 +1,10 @@
 from django.test import TestCase
-import unittest
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 import swapper
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -17,10 +22,10 @@ class SwapperTestCase(TestCase):
     # Tests that should work whether or not default_app.Type is swapped
     def test_fields(self):
         Type = swapper.load_model('default_app', 'Type')
-        fields = {
-            field.name: field
+        fields = dict(
+            (field.name, field)
             for field in Type._meta.fields
-        }
+        )
         self.assertIn('name', fields)
 
     def test_create(self):
@@ -55,10 +60,10 @@ class SwapperTestCase(TestCase):
     @unittest.skipUnless(settings.SWAP, "requires swapped models")
     def test_swap_fields(self):
         Type = swapper.load_model('default_app', 'Type')
-        fields = {
-            field.name: field
+        fields = dict(
+            (field.name, field)
             for field in Type._meta.fields
-        }
+        )
         self.assertIn('code', fields)
 
     @unittest.skipUnless(settings.SWAP, "requires swapped models")

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    py{27,33}-django16-{noswap,swap},
+    py{26,27,33}-django16-{noswap,swap},
     py{27,33,34}-django{17,18}-{noswap,swap}
 
 [tox:travis]
+2.6 = py26-django{16}-{noswap,swap}
 2.7 = py27-django{16,17,18}-{noswap,swap}
 3.3 = py33-django{17,18}-{noswap,swap}
 3.4 = py34-django{17,18}-{noswap,swap}

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist =
-    py{26,27,33}-django16-{noswap,swap},
+    py26-django16-unittest2-{noswap,swap},
+    py{27,33}-django16-{noswap,swap},
     py{27,33,34}-django{17,18}-{noswap,swap}
 
 [tox:travis]
-2.6 = py26-django{16}-{noswap,swap}
+2.6 = py26-django16-unittest2-{noswap,swap}
 2.7 = py27-django{16,17,18}-{noswap,swap}
 3.3 = py33-django{17,18}-{noswap,swap}
 3.4 = py34-django{17,18}-{noswap,swap}
@@ -12,9 +13,10 @@ envlist =
 [testenv]
 commands = python setup.py test
 deps =
-    django16: django>=1.6,<1.7
+    django16: django~=1.6.0
     django17: django>=1.7
     django18: django>=1.8
+    unittest2: unittest2
 setenv =
     noswap: DJANGO_SETTINGS_MODULE=tests.settings
     swap: DJANGO_SETTINGS_MODULE=tests.swap_settings

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ envlist =
 [testenv]
 commands = python setup.py test
 deps =
-    django16: django>=1.6
+    django16: django>=1.6,<1.7
     django17: django>=1.7
     django18: django>=1.8
 setenv =


### PR DESCRIPTION
Currently, 2.6 explodes due to the usage of a dict comprehension.
This commit replaces it with a 2.6 compatible comprehension.