### PR TITLE
Handle contrib apps

### DIFF
--- a/swapper/__init__.py
+++ b/swapper/__init__.py
@@ -111,5 +111,5 @@ def join(app_label, model):
 
 
 def split(model):
-    app_label, model = model.split(".")
+    app_label, _, model = model.rpartition(".")
     return app_label, model

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -52,6 +52,11 @@ class SwapperTestCase(TestCase):
     def test_non_contrib_app_split(self):
         self.assertEqual(swapper.split('alt_app.Type'), ('alt_app', 'Type'))
 
+    def test_contrib_app_split(self):
+        self.assertEqual(
+            swapper.split('alt_app.contrib.named_things.NamedThing'),
+            ('alt_app.contrib.named_things', 'NamedThing'))
+
     # Tests that only work if default_app.Type is swapped
     @unittest.skipUnless(settings.SWAP, "requires swapped models")
     def test_swap_setting(self):

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -49,6 +49,9 @@ class SwapperTestCase(TestCase):
         with self.assertRaises(ImproperlyConfigured):
             swapper.load_model("invalid_app", "Invalid", required=True)
 
+    def test_non_contrib_app_split(self):
+        self.assertEqual(swapper.split('alt_app.Type'), ('alt_app', 'Type'))
+
     # Tests that only work if default_app.Type is swapped
     @unittest.skipUnless(settings.SWAP, "requires swapped models")
     def test_swap_setting(self):

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
 setenv =
     noswap: DJANGO_SETTINGS_MODULE=tests.settings
     swap: DJANGO_SETTINGS_MODULE=tests.swap_settings
+whitelist_externals = rm
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
And apps with dots in their `app_label`.

Currently:

`'django.contrib.comments.Comment'` -> `('django', 'contrib', 'comments', 'Comment')`

With this change:

`'django.contrib.comments.Comment'` -> `('django.contrib.comments', 'Comment')`