### PR TITLE
[fix] Trigger changelog bot for backward incompatible changes

### DIFF
--- a/.github/workflows/bot-changelog-trigger.yml
+++ b/.github/workflows/bot-changelog-trigger.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if echo "$PR_TITLE" | grep -qiE '^\[(feature|fix|change)\]'; then
+          if echo "$PR_TITLE" | grep -qiE '^\[(feature|fix|change!?)\]'; then
             echo "has_noteworthy=true" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

No existing issue.

## Description of Changes

This PR updates the changelog bot trigger workflow to match PR titles starting with `[change!]`.

This allows backward incompatible PRs to run the reusable changelog workflow after maintainer approval, the same as `[feature]`, `[fix]`, and `[change]` PRs.

## Screenshot

Not applicable.